### PR TITLE
fix: 1:1 채팅 수정 (UserChatRoom -> isJoined, joinedDate 추가)

### DIFF
--- a/src/main/java/com/littlebank/finance/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/littlebank/finance/domain/chat/controller/ChatMessageController.java
@@ -113,11 +113,13 @@ public class ChatMessageController {
     public void leaveChatRoom(@Payload RoomLeaveRequest request, Authentication authentication) {
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
 
-        // 나가기 로그 테이블 저장
         RoomLeaveResponse response = new RoomLeaveResponse();
         ChatRoomEventLog eventLog = chatMessageService.leaveChatRoom(customUserDetails.getId(), request, response);
 
-        // 나가기 로그 보내줌
+        if (eventLog == null) {
+            return;
+        }
+
         List<UserChatRoom> participants = chatMessageService.getChatRoomParticipants(request.getRoomId());
         for (UserChatRoom participant : participants) {
             Long receiverId = participant.getUser().getId();

--- a/src/main/java/com/littlebank/finance/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/littlebank/finance/domain/chat/domain/ChatRoom.java
@@ -46,13 +46,10 @@ public class ChatRoom extends BaseEntity {
         this.isDeleted = isDeleted == null ? false : isDeleted;
     }
 
-    public void updateFirstMessageId(ChatMessage message) {
+    public void send(ChatMessage message) {
         if (this.firstMessageId == 0L) {
             this.firstMessageId = message.getId();
         }
-    }
-
-    public void updateLastMessageId(ChatMessage message) {
         if (this.lastMessageId < message.getId()) {
             this.lastMessageId = message.getId();
         }

--- a/src/main/java/com/littlebank/finance/domain/chat/domain/UserChatRoom.java
+++ b/src/main/java/com/littlebank/finance/domain/chat/domain/UserChatRoom.java
@@ -33,21 +33,36 @@ public class UserChatRoom extends BaseEntity {
     private LocalDateTime displayIdx;
     @Column(nullable = false)
     private Long lastReadMessageId;
+    @Column(nullable = false)
+    private Boolean isJoined;
+    @Column(nullable = false)
+    private LocalDateTime joinedDate;
     @Version
     private Long version;
 
     @Builder
-    public UserChatRoom(ChatRoom room, User user, LocalDateTime displayIdx, Long lastReadMessageId) {
+    public UserChatRoom(ChatRoom room, User user, LocalDateTime displayIdx, Long lastReadMessageId, Boolean isJoined, LocalDateTime joinedDate) {
         this.room = room;
         this.user = user;
         this.displayIdx = displayIdx == null ? LocalDateTime.now() : displayIdx;
         this.lastReadMessageId = lastReadMessageId == null ? 0L : lastReadMessageId;
+        this.isJoined = isJoined == null ? true : isJoined;
+        this.joinedDate = joinedDate == null ? LocalDateTime.now() : joinedDate;
     }
 
     public void updateLastReadMessageId(Long messageId) {
         if (this.lastReadMessageId < messageId) {
             this.lastReadMessageId = messageId;
         }
+    }
+
+    public void joinPrivateRoom() {
+        this.isJoined = true;
+        this.joinedDate = LocalDateTime.now();
+    }
+
+    public void leavePrivateRoom() {
+        this.isJoined = false;
     }
 
 }

--- a/src/main/java/com/littlebank/finance/domain/chat/domain/repository/impl/CustomChatMessageRepositoryImpl.java
+++ b/src/main/java/com/littlebank/finance/domain/chat/domain/repository/impl/CustomChatMessageRepositoryImpl.java
@@ -79,10 +79,14 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
                 .and(blockedMessageCondition(userId, roomRange))
                 .and(cm.id.lt(lastMessageId))
                 .and(cm.timestamp.goe(
-                        JPAExpressions.select(ucr.createdDate)
+                        JPAExpressions.select(ucr.joinedDate)
                                 .from(ucr)
-                                .where(ucr.room.id.eq(roomId).and(ucr.user.id.eq(userId)))
-                ));
+                                .where(
+                                        ucr.room.id.eq(roomId),
+                                        ucr.user.id.eq(userId)
+                                )
+                        )
+                );
 
         List<APIMessageResponse> results = queryFactory
                 .select(Projections.constructor(
@@ -126,6 +130,13 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
         return new PageImpl<>(results, pageable, totalCount);
     }
 
+    /**
+     * 1:1 채팅일 때 친구를 차단했다면 차단 시간 이전의 메시지만 조회
+     *
+     * @param userId
+     * @param roomRange
+     * @return
+     */
     private BooleanExpression blockedMessageCondition(Long userId, RoomRange roomRange) {
         if (roomRange == RoomRange.GROUP) {
             return null;

--- a/src/main/java/com/littlebank/finance/domain/chat/service/ChatService.java
+++ b/src/main/java/com/littlebank/finance/domain/chat/service/ChatService.java
@@ -5,6 +5,7 @@ import com.littlebank.finance.domain.chat.domain.ChatRoomEventLog;
 import com.littlebank.finance.domain.chat.domain.ChatRoomEventLogDetail;
 import com.littlebank.finance.domain.chat.domain.UserChatRoom;
 import com.littlebank.finance.domain.chat.domain.constant.EventType;
+import com.littlebank.finance.domain.chat.domain.constant.RoomRange;
 import com.littlebank.finance.domain.chat.domain.repository.*;
 import com.littlebank.finance.domain.chat.dto.UserFriendInfoDto;
 import com.littlebank.finance.domain.chat.dto.request.ChatRoomCreateRequest;
@@ -52,13 +53,18 @@ public class ChatService {
                         .build()
         );
 
-        ChatRoomEventLog eventLog = chatRoomEventLogRepository.save(
-                ChatRoomEventLog.builder()
-                        .eventType(EventType.INVITE)
-                        .room(room)
-                        .agent(user)
-                        .build()
-        );
+        ChatRoomEventLog eventLog;
+        if (room.getRange() == RoomRange.GROUP) {
+            eventLog = chatRoomEventLogRepository.save(
+                    ChatRoomEventLog.builder()
+                            .eventType(EventType.INVITE)
+                            .room(room)
+                            .agent(user)
+                            .build()
+            );
+        } else {
+            eventLog = null;
+        }
 
         long joinedCount = request.getParticipantIds().stream()
                 .map(userRepository::findById)
@@ -71,7 +77,7 @@ public class ChatService {
                                             .build()
                             );
 
-                    if (joinedUser.getUser().getId() != userId) {
+                    if (room.getRange() != RoomRange.PRIVATE && joinedUser.getUser().getId() != userId) {
                         chatRoomEventLogDetailRepository.save(
                                 ChatRoomEventLogDetail.builder()
                                         .log(eventLog)


### PR DESCRIPTION
1. 이벤트 로그 생성 x
2. 채팅방 나가기 시, isJoined를 업데이트
3. 나간 상태에서 메시지 전송 시, isJoined, joinedDate 업데이트
4. 채팅방 목록 조회 시, 읽지 않은 메시지 조회 로직 수정
5. 단일 채팅방 상세 조회 시, UserChatRoom의 isJoined true 조건 추가
6. 메시지 조회 시, joinedDate 이후 메시지들만 조회
7. 로그 조회 시, joinedDate 이후 로그만 조회